### PR TITLE
feat: display hwmon name

### DIFF
--- a/fanclass.cpp
+++ b/fanclass.cpp
@@ -38,6 +38,17 @@ QString fanClass::getHwmonNum() const
     return m_strHwmonNum;
 }
 
+QString fanClass::getHwmonName() const {
+    QFile fan_file(m_strHwmon + "/name");
+    QString name;
+    if( fan_file.open(QIODevice::ReadOnly) ) {
+        name = fan_file.readAll().trimmed();
+        fan_file.close();
+    }
+
+    return name;
+}
+
 QString fanClass::getFan() const {
     return m_strFan;
 }

--- a/fanclass.h
+++ b/fanclass.h
@@ -21,6 +21,7 @@ public:
     void setFan(const QString& strFan );
     QString getHwmon() const;
     QString getHwmonNum() const;
+    QString getHwmonName() const;
     QString getFan() const;
     QString getPwm() const;
     int getFanAlarm() const;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -21,7 +21,7 @@ MainWindow::MainWindow(QWidget *parent)
     g_systemdDir = "/etc/systemd/system";
     g_systemdName = "controlfans";
 
-    setFixedSize(800, 470);
+    //setFixedSize(800, 470);
 
     setupMenuBar();
     hideGroup();
@@ -372,69 +372,91 @@ void MainWindow::refreshDeleteSystemDAllStanza()
 
 void MainWindow::enableHwmon(){
     // enable all available hwmon
-
-    QDir hwmon0Dir = g_hwmonDir + "/hwmon0";
-    if (hwmon0Dir.exists()) {
+    QString name;
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon0");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon0radioButton->setText("hwmon0 (" + name + ")");
         ui->hwmon0radioButton->setCheckable(true);
         ui->hwmon0radioButton->setDisabled(false);
     }
 
-    QDir hwmon1Dir = g_hwmonDir + "/hwmon1";
-    if (hwmon1Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon1");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon1radioButton->setText("hwmon1 (" + name + ")");
         ui->hwmon1radioButton->setCheckable(true);
         ui->hwmon1radioButton->setDisabled(false);
     }
 
-    QDir hwmon2Dir = g_hwmonDir + "/hwmon2";
-    if (hwmon2Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon2");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon2radioButton->setText("hwmon2 (" + name + ")");
         ui->hwmon2radioButton->setCheckable(true);
         ui->hwmon2radioButton->setDisabled(false);
     }
 
-    QDir hwmon3Dir = g_hwmonDir + "/hwmon3";
-    if (hwmon3Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon3");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon3radioButton->setText("hwmon3 (" + name + ")");
         ui->hwmon3radioButton->setCheckable(true);
         ui->hwmon3radioButton->setDisabled(false);
     }
 
-    QDir hwmon4Dir = g_hwmonDir + "/hwmon4";
-    if (hwmon4Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon4");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon4radioButton->setText("hwmon4 (" + name + ")");
         ui->hwmon4radioButton->setCheckable(true);
         ui->hwmon4radioButton->setDisabled(false);
     }
 
-    QDir hwmon5Dir = g_hwmonDir + "/hwmon5";
-    if (hwmon5Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon5");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon5radioButton->setText("hwmon5 (" + name + ")");
         ui->hwmon5radioButton->setCheckable(true);
         ui->hwmon5radioButton->setDisabled(false);
     }
 
-    QDir hwmon6Dir = g_hwmonDir + "/hwmon6";
-    if (hwmon6Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon6");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon6radioButton->setText("hwmon6 (" + name + ")");
         ui->hwmon6radioButton->setCheckable(true);
         ui->hwmon6radioButton->setDisabled(false);
     }
 
-    QDir hwmon7Dir = g_hwmonDir + "/hwmon7";
-    if (hwmon7Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon7");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon7radioButton->setText("hwmon7 (" + name + ")");
         ui->hwmon7radioButton->setCheckable(true);
         ui->hwmon7radioButton->setDisabled(false);
     }
 
-    QDir hwmon8Dir = g_hwmonDir + "/hwmon8";
-    if (hwmon8Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon8");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon8radioButton->setText("hwmon8 (" + name + ")");
         ui->hwmon8radioButton->setCheckable(true);
         ui->hwmon8radioButton->setDisabled(false);
     }
 
-    QDir hwmon9Dir = g_hwmonDir + "/hwmon9";
-    if (hwmon9Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon9");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon9radioButton->setText("hwmon9 (" + name + ")");
         ui->hwmon9radioButton->setCheckable(true);
         ui->hwmon9radioButton->setDisabled(false);
     }
 
-    QDir hwmon10Dir = g_hwmonDir + "/hwmon10";
-    if (hwmon10Dir.exists()) {
+    g_fanDev.setHwmon(g_hwmonDir, "hwmon10");
+    name = g_fanDev.getHwmonName();
+    if ( !name.isEmpty() ) {
+        ui->hwmon10radioButton->setText("hwmon10 (" + name + ")");
         ui->hwmon10radioButton->setCheckable(true);
         ui->hwmon10radioButton->setDisabled(false);
     }

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
+    <width>1006</width>
     <height>470</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -29,7 +29,7 @@
      <rect>
       <x>0</x>
       <y>0</y>
-      <width>791</width>
+      <width>1001</width>
       <height>381</height>
      </rect>
     </property>
@@ -41,7 +41,7 @@
       <rect>
        <x>10</x>
        <y>10</y>
-       <width>121</width>
+       <width>291</width>
        <height>361</height>
       </rect>
      </property>
@@ -53,7 +53,7 @@
        <rect>
         <x>10</x>
         <y>30</y>
-        <width>104</width>
+        <width>281</width>
         <height>326</height>
        </rect>
       </property>
@@ -141,7 +141,7 @@
     <widget class="QGroupBox" name="fangroupBox">
      <property name="geometry">
       <rect>
-       <x>130</x>
+       <x>320</x>
        <y>10</y>
        <width>141</width>
        <height>211</height>
@@ -236,9 +236,9 @@
     <widget class="QGroupBox" name="fanDatagroupBox">
      <property name="geometry">
       <rect>
-       <x>270</x>
+       <x>470</x>
        <y>10</y>
-       <width>511</width>
+       <width>521</width>
        <height>131</height>
       </rect>
      </property>
@@ -331,9 +331,9 @@
     <widget class="QGroupBox" name="pwmDatagroupBox">
      <property name="geometry">
       <rect>
-       <x>270</x>
+       <x>470</x>
        <y>140</y>
-       <width>511</width>
+       <width>521</width>
        <height>231</height>
       </rect>
      </property>
@@ -345,7 +345,7 @@
        <rect>
         <x>10</x>
         <y>30</y>
-        <width>494</width>
+        <width>491</width>
         <height>188</height>
        </rect>
       </property>
@@ -511,9 +511,9 @@
    <widget class="QWidget" name="layoutWidget">
     <property name="geometry">
      <rect>
-      <x>25</x>
+      <x>20</x>
       <y>390</y>
-      <width>751</width>
+      <width>951</width>
       <height>28</height>
      </rect>
     </property>
@@ -575,7 +575,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
+     <width>1006</width>
      <height>22</height>
     </rect>
    </property>


### PR DESCRIPTION
- Displaying hwmon name beside it in the main window. (e.g. hwmon1 (acpitz))
- Widening main window to support longer hwmon labels.