### PR TITLE
Feat systemd physical path

### DIFF
--- a/fanclass.cpp
+++ b/fanclass.cpp
@@ -1,5 +1,6 @@
 #include "fanclass.h"
 #include <QFile>
+#include <QFileInfo>
 
 fanClass::fanClass(QObject *parent)
     : QObject(parent)
@@ -36,6 +37,12 @@ QString fanClass::getHwmon() const {
 QString fanClass::getHwmonNum() const
 {
     return m_strHwmonNum;
+}
+
+QString fanClass::getHwmonDevicePath() const
+{
+    QFileInfo dev(m_strHwmon + "/device");
+    return dev.canonicalFilePath()+"/hwmon/hwmon[[:print:]]*";
 }
 
 QString fanClass::getHwmonName() const {

--- a/fanclass.h
+++ b/fanclass.h
@@ -22,6 +22,7 @@ public:
     QString getHwmon() const;
     QString getHwmonNum() const;
     QString getHwmonName() const;
+    QString getHwmonDevicePath() const;
     QString getFan() const;
     QString getPwm() const;
     int getFanAlarm() const;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1006</width>
+    <width>1002</width>
     <height>470</height>
    </rect>
   </property>
@@ -575,7 +575,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1006</width>
+     <width>1002</width>
      <height>22</height>
     </rect>
    </property>


### PR DESCRIPTION
- Services created may not worked after restart as the hwmon numbers can change when hardware is enumerated. So this branch uses physical device paths in systemd service files.
- Previously Create systemD All button made a service file for all hwmons. In this branch it only does so for the current hwmon. The reason is that earlier method caused unexpected  behavior like creating service lines that where not valid as the device did not support such interaction.
- Replaced sh with bash to support [[:print:]] directory match pattern which is necessary for new .service file with physical path to work.
- Clipped the right side of main window a bit to match the inner rectangle.   