### PR TITLE
fix: add lm_sensors to After and removing Before

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -849,8 +849,7 @@ void MainWindow::createSystemDStanza()
         QString s = "[Unit]\n";
         s = s + "Description=" + g_systemdName + " " + g_fanDev.getHwmonName() + " " + g_fanDev.getFan() + "\n";
         s = s + "DefaultDependencies=no\n";
-        s = s + "After=sysinit.target local-fs.target suspend.target hibernate.target\n";
-        s = s + "Before=basic.target\n\n";
+        s = s + "After=sysinit.target local-fs.target suspend.target hibernate.target lm_sensors.service\n\n";
         s = s + "[Service]\n";
         s = s + "Type=oneshot\n";
         s = s + createSystemDExexStart() + "\n";


### PR DESCRIPTION
At least in my system (Manjaro Linux x64 6.1.12-1)  service fails if executed before lm_sensors. And lm_sensors runs after basic.target. So I changed the order accordingly.
Here is a working plot in which we can see ControlFANs near the end:

![b](https://user-images.githubusercontent.com/19843654/223968875-f3e62661-e007-4ddf-bb34-3a5dd7fa5cf7.svg)


